### PR TITLE
Decouple State and Health from each other, display both

### DIFF
--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -14,11 +14,12 @@ export const theme: DefaultTheme = {
     darkOne: "#1f2430",
     darkTwo: "#191e2a",
     lightOne: "#fff1e5",
-    lightTwo: "#FFFAF5",
+    lightTwo: "#ffaf5",
     red: "#ee2f01",
     green: "#00ab4e",
     blue: "#26a8ff",
     orange: "#fcaf17",
+    purple: "#c06bd0",
   },
   shadow: {
     card: "4px 4px 20px rgba(0, 0, 0, 0.17)",

--- a/ui/src/components/card/CardInstance.tsx
+++ b/ui/src/components/card/CardInstance.tsx
@@ -3,8 +3,9 @@ import styled from "styled-components";
 
 import { APP_CONFIG } from "../../../../config";
 import InstanceProps from "../../utils/InstanceProps";
-import { getStatusIcon } from "../../utils/getStatus";
-import CardInstanceStatusOverlay from "./CardInstanceStatusOverlay";
+import { getStateIcon } from "../../utils/getState";
+import { getHealthIcon } from "../../utils/getHealth";
+import CardInstanceOverlay from "./CardInstanceOverlay";
 import { transparentize } from "polished";
 import getDate from "../../utils/getDate";
 import CopyText from "../shared/CopyText";
@@ -61,7 +62,11 @@ const InstanceRowKey = styled.div`
   padding-right: 4px;
 `;
 
-const SmallStatusIcon = styled.div`
+const SmallStateIcon = styled.div`
+  cursor: pointer;
+`;
+
+const SmallHealthIcon = styled.div`
   cursor: pointer;
 `;
 
@@ -116,19 +121,26 @@ const CardInstance = (props: {
     props.instance.instanceVersion !== "primal" &&
     props.instance.instanceUpdatingToVersion;
 
-  const statusCode = instanceIsBooting
+  const stateCode = instanceIsBooting
     ? 0
     : instanceIsGhost
     ? 1
     : instanceIsUpdating
     ? 2
-    : props.instance.instanceHealthCode;
+    : 3;
 
-  const [isOverlayVisible, setIsOverlayVisible] = useState(false);
+  const healthCode = props.instance.instanceHealthCode || 0;
+
+  const [isStateOverlayVisible, setIsStateOverlayVisible] = useState(false);
+  const [isHealthOverlayVisible, setIsHealthOverlayVisible] = useState(false);
 
   useEffect(() => {
-    setIsOverlayVisible(statusCode < 3);
-  }, [statusCode]);
+    setIsStateOverlayVisible(stateCode < 3);
+  }, [stateCode]);
+
+  useEffect(() => {
+    setIsHealthOverlayVisible(healthCode > 1);
+  }, [healthCode]);
 
   const filteredAdvancedCardData = Object.entries(props.instance).filter(
     row => {
@@ -142,10 +154,20 @@ const CardInstance = (props: {
 
   return (
     <InstanceWrapper>
-      {isOverlayVisible && (
-        <CardInstanceStatusOverlay
-          onClick={() => setIsOverlayVisible(false)}
-          statusCode={statusCode}
+      {isStateOverlayVisible && (
+        <CardInstanceOverlay
+          onClick={() => setIsStateOverlayVisible(false)}
+          type="state"
+          stateorHealthCode={stateCode}
+          instance={props.instance}
+        />
+      )}
+
+      {isHealthOverlayVisible && (
+        <CardInstanceOverlay
+          onClick={() => setIsHealthOverlayVisible(false)}
+          type="health"
+          stateorHealthCode={healthCode}
           instance={props.instance}
         />
       )}
@@ -157,13 +179,22 @@ const CardInstance = (props: {
             <InstanceNumber>#{props.instanceNumber}</InstanceNumber>
           </InstanceName>
 
-          {!isOverlayVisible && (
-            <SmallStatusIcon
+          {!isStateOverlayVisible && (
+            <SmallStateIcon
               title="Show Info"
-              onClick={() => setIsOverlayVisible(true)}
+              onClick={() => setIsStateOverlayVisible(true)}
             >
-              {getStatusIcon(statusCode)}
-            </SmallStatusIcon>
+              {getStateIcon(stateCode)}
+            </SmallStateIcon>
+          )}
+
+          {!isStateOverlayVisible && (
+            <SmallHealthIcon
+              title="Show Info"
+              onClick={() => setIsHealthOverlayVisible(true)}
+            >
+              {getHealthIcon(healthCode)}
+            </SmallHealthIcon>
           )}
         </InstanceHeader>
         <div>

--- a/ui/src/components/card/CardInstance.tsx
+++ b/ui/src/components/card/CardInstance.tsx
@@ -125,10 +125,10 @@ const CardInstance = (props: {
   const stateCode = instanceIsBooting
     ? 0
     : instanceIsGhost
-    ? 1
-    : instanceIsUpdating
-    ? 2
-    : 3;
+      ? 1
+      : instanceIsUpdating
+        ? 2
+        : 3;
 
   const healthCode = props.instance.instanceHealthCode || 0;
 
@@ -180,23 +180,20 @@ const CardInstance = (props: {
             <InstanceNumber>#{props.instanceNumber}</InstanceNumber>
           </InstanceName>
 
-          {!isStateOverlayVisible && (
-            <SmallStateIcon
-              title="Show Info"
-              onClick={() => setIsStateOverlayVisible(true)}
-            >
-              {getStateIcon(stateCode)}
-            </SmallStateIcon>
-          )}
+          <SmallStateIcon
+            title="Show Info"
+            onClick={() => setIsStateOverlayVisible(true)}
+          >
+            {getStateIcon(stateCode)}
+          </SmallStateIcon>
 
-          {!isStateOverlayVisible && (
-            <SmallHealthIcon
-              title="Show Info"
-              onClick={() => setIsHealthOverlayVisible(true)}
-            >
-              {getHealthIcon(healthCode)}
-            </SmallHealthIcon>
-          )}
+          <SmallHealthIcon
+            title="Show Info"
+            onClick={() => setIsHealthOverlayVisible(true)}
+          >
+            {getHealthIcon(healthCode)}
+          </SmallHealthIcon>
+
         </InstanceHeader>
         <div>
           <InstanceRow>

--- a/ui/src/components/card/CardInstance.tsx
+++ b/ui/src/components/card/CardInstance.tsx
@@ -64,6 +64,7 @@ const InstanceRowKey = styled.div`
 
 const SmallStateIcon = styled.div`
   cursor: pointer;
+  padding-right: 10px;
 `;
 
 const SmallHealthIcon = styled.div`

--- a/ui/src/components/card/CardInstanceOverlay.tsx
+++ b/ui/src/components/card/CardInstanceOverlay.tsx
@@ -3,7 +3,8 @@ import styled from "styled-components";
 import { transparentize } from "polished";
 
 import InstanceProps from "../../utils/InstanceProps";
-import { getStatusIcon, getStatusMessage } from "../../utils/getStatus";
+import { getStateIcon, getStateMessage } from "../../utils/getState";
+import { getHealthIcon, getHealthMessage } from "../../utils/getHealth";
 
 const UpdatingInstance = styled.div`
   width: 100%;
@@ -34,17 +35,29 @@ const UpdatingInstance = styled.div`
   }
 `;
 
-const CardInstanceStatusOverlay = (props: {
+const CardInstanceOverlay = (props: {
   onClick: () => void;
-  statusCode: number;
+  type: string;
+  stateorHealthCode: number;
   instance: InstanceProps;
 }) => {
+  if (props.type === "state") {
   return (
     <UpdatingInstance title="Hide Info" onClick={props.onClick}>
-      {getStatusIcon(props.statusCode, "40px")}
-      {getStatusMessage(props.statusCode, props.instance)}
+      {getStateIcon(props.stateorHealthCode, "40px")}
+      {getStateMessage(props.stateorHealthCode, props.instance)}
     </UpdatingInstance>
-  );
+    );
+   };
+
+  if (props.type === "health") {
+  return (
+    <UpdatingInstance title="Hide Info" onClick={props.onClick}>
+      {getHealthIcon(props.stateorHealthCode, "40px")}
+      {getHealthMessage(props.instance)}
+    </UpdatingInstance>
+    );
+  };
 };
 
-export default CardInstanceStatusOverlay;
+export default CardInstanceOverlay;

--- a/ui/src/utils/InstanceProps.ts
+++ b/ui/src/utils/InstanceProps.ts
@@ -25,6 +25,9 @@ export default interface InstanceProps {
   instanceID: string;
   instanceType: string;
 
+  // Instance State
+  instanceStateCode: number;
+
   // Health Check
   instanceLastHealthyAt: string;
   instanceHealthCode: number;

--- a/ui/src/utils/getHealth.tsx
+++ b/ui/src/utils/getHealth.tsx
@@ -1,0 +1,30 @@
+import React from "react";
+
+import InstanceProps from "./InstanceProps";
+
+import IconInfo from "../components/icons/IconInfo";
+import IconWarning from "../components/icons/IconWarning";
+import IconError from "../components/icons/IconError";
+import IconOkay from "../components/icons/IconOkay";
+import { theme } from "../App";
+
+export const getHealthIcon = (healthCode: number, size?: string) => {
+  const iconSize = size || "20px";
+  switch (healthCode) {
+    case 0:
+      return <IconOkay color={theme.color.green} width={iconSize} />;
+    case 1:
+      return <IconInfo color={theme.color.blue} width={iconSize} />;
+    case 2:
+      return <IconWarning color={theme.color.orange} width={iconSize} />;
+    case 3:
+      return <IconError color={theme.color.red} width={iconSize} />;
+    default:
+  }
+};
+
+export const getHealthMessage = (
+  instance: InstanceProps,
+) => {
+  return instance.instanceHealthMessage;
+};

--- a/ui/src/utils/getHealth.tsx
+++ b/ui/src/utils/getHealth.tsx
@@ -9,7 +9,7 @@ import IconOkay from "../components/icons/IconOkay";
 import { theme } from "../App";
 
 export const getHealthIcon = (healthCode: number, size?: string) => {
-  const iconSize = size || "20px";
+  const iconSize = size || "25px";
   switch (healthCode) {
     case 0:
       return <IconOkay color={theme.color.green} width={iconSize} />;

--- a/ui/src/utils/getState.tsx
+++ b/ui/src/utils/getState.tsx
@@ -7,7 +7,7 @@ import IconAdd from "../components/icons/IconAdd";
 import { theme } from "../App";
 
 export const getStateIcon = (stateCode: number, size?: string) => {
-  const iconSize = size || "20px";
+  const iconSize = size || "25px";
   switch (stateCode) {
     case 0:
       return <IconAdd color={theme.color.purple} width={iconSize} />;

--- a/ui/src/utils/getState.tsx
+++ b/ui/src/utils/getState.tsx
@@ -4,40 +4,26 @@ import InstanceProps from "./InstanceProps";
 
 import IconUpdating from "../components/icons/IconUpdating";
 import IconAdd from "../components/icons/IconAdd";
-import IconInfo from "../components/icons/IconInfo";
-import IconWarning from "../components/icons/IconWarning";
-import IconError from "../components/icons/IconError";
-import IconOkay from "../components/icons/IconOkay";
 import { theme } from "../App";
 
-export const getStatusIcon = (statusCode: number, size?: string) => {
+export const getStateIcon = (stateCode: number, size?: string) => {
   const iconSize = size || "20px";
-  switch (statusCode) {
+  switch (stateCode) {
     case 0:
-      return <IconAdd color={theme.color.green} width={iconSize} />;
+      return <IconAdd color={theme.color.purple} width={iconSize} />;
     case 1:
       return <IconAdd color={theme.color.lightOne} width={iconSize} />;
     case 2:
-      return <IconUpdating color={theme.color.green} width={iconSize} />;
-    case 3:
-    case 4:
-    case 5:
-      return <IconOkay color={theme.color.green} width={iconSize} />;
-    case 6:
-      return <IconInfo color={theme.color.blue} width={iconSize} />;
-    case 7:
-      return <IconWarning color={theme.color.orange} width={iconSize} />;
-    case 8:
-      return <IconError color={theme.color.red} width={iconSize} />;
+      return <IconUpdating color={theme.color.purple} width={iconSize} />;
     default:
   }
 };
 
-export const getStatusMessage = (
-  statusCode: number,
+export const getStateMessage = (
+  stateCode: number,
   instance: InstanceProps,
 ) => {
-  switch (statusCode) {
+  switch (stateCode) {
     case 0:
       return <>Booting New Instance!</>;
     case 1:

--- a/ui/styled.d.ts
+++ b/ui/styled.d.ts
@@ -11,6 +11,7 @@ declare module "styled-components" {
       green: string;
       blue: string;
       orange: string;
+      purple: string;
     };
     shadow: {
       card: string;


### PR DESCRIPTION
SUMMARY
-
Change `instanceHealthCode` to only be for health...

ISSUE
-
Right now this property can be changed and modified to decide the instances health and also whether an instance is currently updating, etc.

This means that for Monitor and the UI there are issues:
1. The Monitor has to assume that anything other than unhealthy codes are fine
2. The UI can't handle the case where an instance in a `warning` state is also currently updating. In this case, the updating message completely hides the health which is deeply undesirable.

SOLUTION
-
Split the codes out into two distinct values:
`instanceStateCode` which is used for determining if an instance is `updating`, in `ghostMode`, etc.
and
`instanceHealthCode` which is only used for reporting health

PREVIEW
-
![image](https://user-images.githubusercontent.com/24733798/70536001-e8324480-1b55-11ea-8092-bb2cefaf46ca.png)
