### PR TITLE
Add Cleardown

### DIFF
--- a/api/controllers/instances.js
+++ b/api/controllers/instances.js
@@ -57,7 +57,6 @@ export const doneUpdatingInstance = request => {
   const requestItems = Object.entries(request);
   const data = {};
   let shouldCleardown = false;
-  const instancesToDelete = [];
 
   requestItems.forEach(item => {
     // if the request item key exists in the ALLOWED_DATA array, save it
@@ -77,12 +76,8 @@ export const doneUpdatingInstance = request => {
         if (instance.instanceID !== data.instanceID &&
           instance.instanceUpdatingToVersion !== data.instanceVersion
         ) {
-          instancesToDelete.push(instance.instanceID);
+          db.instances.remove({ instanceID: instance.instanceID }, true);
         }
-      });
-
-      instancesToDelete.forEach(instanceID => {
-        db.instances.remove({ instanceID: instanceID }, true);
       });
     }
   }


### PR DESCRIPTION
This PR adds the cleardown logic to remove old/strategically retired instances from memory when an update is run

Initially this also had extra logic to handle ghostMode instances but I don't think it's worth having that as it adds complexity, and increases the chances of the Status Page having an outdated record of the Stacks

So the approach was clear down as much as possible, and rely on `/done` and healthchecks to put back`ghostMode` instances in the rare case we delete them